### PR TITLE
Changed switch case indention

### DIFF
--- a/formatter/src/main/resources/itm-java-codeformat/java_codestyle_formatter.xml
+++ b/formatter/src/main/resources/itm-java-codeformat/java_codestyle_formatter.xml
@@ -121,7 +121,7 @@
         <setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>


### PR DESCRIPTION
Changed setting property "org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" to true from false.

**Description**

As I mainly work for the LHM I of course also comply to official code style and use this formatter in all of my Java code projects.
I have the issue that the readability of switch case statements becomes harder the more enclosed statements I have:
Example:
Now:
```java
switch (someString) {
case "A" -> {
	switch (someContextString) {
	case "A":
		doActionForA();
		break;
	case "B":
		doActionForB();
		break;
	default:
		throw new IllegalArgumentException("Action for context [" + someContextString + "] has not been implemented yet or is not supported!");
    }
    break;
default:
	throw new IllegalArgumentException("Action for string [" + someString + "] has not been implemented yet or is not supported!");
}
}
```
To:
```java
switch (someString) {
	case "A" -> {
		switch (someContextString) {
			case "A":
				doActionForA();
				break;
			case "B":
				doActionForB();
				break;
			default:
				throw new IllegalArgumentException("Action for context [" + someContextString + "] has not been implemented yet or is not supported!");
		}
		break;
	default:
		throw new IllegalArgumentException("Action for string [" + someString + "] has not been implemented yet or is not supported!");
	}
}
```